### PR TITLE
Bug fix for issue 8

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -93,3 +93,8 @@
 - Made it easier to set a specific time when clicking `manual adjust` in config
 - Changed text keys back to text
 - Overhauled readme.md
+
+### 2.2.1
+
+- Moved all logic to use 1.20.2 logic
+- Fixed misspelling of `replace`

--- a/data/timeadjust/function/runtime/faster/addtick.mcfunction
+++ b/data/timeadjust/function/runtime/faster/addtick.mcfunction
@@ -1,3 +1,3 @@
 time add 1t
-execute if score TimeAdjust.CurrentTime TimeAdjust matches 0 run scoreboard players add TimeAdjust.Day TimeAdjust 1
+scoreboard players operation TimeAdjust.Tick TimeAdjust -= TimeAdjust.Total TimeAdjust
 execute if score TimeAdjust.Tick TimeAdjust >= TimeAdjust.Total TimeAdjust run function timeadjust:runtime/faster/addtick

--- a/data/timeadjust/function/runtime/slower/inctick.mcfunction
+++ b/data/timeadjust/function/runtime/slower/inctick.mcfunction
@@ -1,2 +1,2 @@
 scoreboard players operation TimeAdjust.Tick TimeAdjust -= #TimeAdjust.20 TimeAdjust
-$schedule function timeadjust:tick $(incTick)t replac
+$schedule function timeadjust:tick $(incTick)t replace

--- a/data/timeadjust/function/tick.mcfunction
+++ b/data/timeadjust/function/tick.mcfunction
@@ -1,4 +1,3 @@
-schedule function timeadjust:tick 1t replace
 gamerule advance_time false
-execute if score TimeAdjust.Total TimeAdjust matches ..19 run return run function timeadjust:runtime/faster/cycle
-execute if score TimeAdjust.Total TimeAdjust matches 20.. run function timeadjust:runtime/slower/cycle
+execute if score TimeAdjust.Total TimeAdjust matches 20.. run return run function timeadjust:runtime/slower/cycle with storage timeadjust:data
+function timeadjust:runtime/faster/cycle


### PR DESCRIPTION
Release 2.2.0 for 1.21.11 was using a mix of logic between 1.13 (old logic) and 1.20.2 (optimized logic). These 2 logic types do not mesh and caused problems when trying to do so. All logic has been updated to 1.20.2 logic and works as intended for both day and night.